### PR TITLE
Allow for pool_size > 4G

### DIFF
--- a/pslab.c
+++ b/pslab.c
@@ -314,7 +314,7 @@ int pslab_pre_recover(char *name, uint32_t *slab_sizes, int slab_max,
 
 bool pslab_force;
 
-int pslab_create(char *pool_name, uint32_t pool_size, uint32_t slab_page_size,
+int pslab_create(char *pool_name, size_t pool_size, uint32_t slab_page_size,
         uint32_t *slabclass_sizes, int slabclass_num) {
 
     size_t mapped_len;

--- a/pslab.h
+++ b/pslab.h
@@ -21,7 +21,7 @@
 #define pslab_item_data_persist(it) pmem_persist((it)->data, ITEM_dtotal(it)
 #define pslab_item_data_flush(it) pmem_flush((it)->data, ITEM_dtotal(it))
 
-int pslab_create(char *pool_name, uint32_t pool_size, uint32_t slab_size,
+int pslab_create(char *pool_name, size_t pool_size, uint32_t slab_size,
     uint32_t *slabclass_sizes, int slabclass_num);
 int pslab_pre_recover(char *name, uint32_t *slab_sizes, int slab_max, int slab_page_size);
 int pslab_do_recover(void);


### PR DESCRIPTION
In pslab_create(), pool_size is type uint32_t, which overflows when it is > 4G. Changing it to size_t allows for a pmem pool > 4G.