### PR TITLE
Patch crash-consistency violations.

### DIFF
--- a/items.c
+++ b/items.c
@@ -522,7 +522,7 @@ int do_item_link(item *it, const uint32_t hv) {
 
         /* Allocate a new CAS ID before link so CAS ID is crash consistent */
         ITEM_set_cas(it, (settings.use_cas) ? get_cas_id() : 0);
-        /* Atomic odification to same flags field should happen sequentially */
+        /* Atomic modification to same flags field happen sequentially */
         atomic_store(&it->it_flags, atomic_load(&it->it_flags) | ITEM_LINKED);
         pmem_member_persist(it, it_flags);
     } else {

--- a/items.c
+++ b/items.c
@@ -537,7 +537,9 @@ int do_item_link(item *it, const uint32_t hv) {
 
         /* Allocate a new CAS ID before link so CAS ID is crash consistent */
         ITEM_set_cas(it, (settings.use_cas) ? get_cas_id() : 0);
-        /* Atomic modification to same flags field happen sequentially */
+        pmem_member_persist(it, data->cas);
+        
+        /* Link item last for atomicity */
         atomic_store(&it->it_flags, atomic_load(&it->it_flags) | ITEM_LINKED);
         pmem_member_persist(it, it_flags);
     } else {


### PR DESCRIPTION
This ensures that CAS IDs are properly ordered and recovered when the persistent slab is recovered. 

This addressed and closes https://github.com/lenovo/memcached-pmem/issues/4 (3 bugs).